### PR TITLE
Improve documentation for event-driven transition

### DIFF
--- a/event-driven/README.md
+++ b/event-driven/README.md
@@ -17,17 +17,16 @@ upload an image via the frontend and later retrieve the processed image.
 
 ## Running locally
 
-The included `docker-compose.yml` spins up all services.  Ensure Docker is
-installed then run:
+1. Build and start the stack
 
-```bash
-cd event-driven
-docker compose up --build
-```
+   ```bash
+   cd event-driven
+   docker compose up --build
+   ```
 
-The frontend will be available on http://localhost:8080. Upload an image and the
-page will show the original and processed result on the same screen. It polls
-automatically until the conversion finishes so no manual refresh is needed.
+2. Open <http://localhost:8080> and upload an image. The page shows both the
+   original and processed version and automatically refreshes until the job
+   completes.
 
 Below the images two charts summarize performance. Before uploading you can pick
 one or more thread counts (1, 2, 4 or 6), the number of kernel passes and how

--- a/microservices/README.md
+++ b/microservices/README.md
@@ -16,20 +16,26 @@ microservices/
       Makefile        # builds bin/grayscale
 ```
 
+## Quick start
+
 Run the service locally with Docker:
 
-```bash
-cd microservices/grayscale
-docker build -t grayscale-service .
-docker run --rm -p 5000:5000 grayscale-service
-```
+1. Build and start the container
 
-Then POST an image to `http://localhost:5000/grayscale` with multipart form data using the field `image` and the service will return the processed PNG.
-You can test this easily with the helper script `grayscale/test_client.py`:
+   ```bash
+   cd microservices/grayscale
+   docker build -t grayscale-service .
+   docker run --rm -p 5000:5000 grayscale-service
+   ```
 
-```bash
-python3 microservices/grayscale/test_client.py path/to/image.jpg output.png
-```
+2. Send an image to the service
+
+   ```bash
+   python3 microservices/grayscale/test_client.py path/to/image.jpg output.png
+   ```
+
+   The service accepts a POST request to `/grayscale` with the file field `image`
+   and returns the processed PNG.
 
 
 ### Benchmark script

--- a/monolithic/README.md
+++ b/monolithic/README.md
@@ -18,6 +18,16 @@ sudo apt install build-essential time python3 python3-pip \
 These packages provide `gcc`, `make`, `/usr/bin/time` and the Python
 libraries used by the benchmarking script.
 
+## Quick start
+
+```bash
+cd monolithic
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+./scripts/bench_and_plot_monolithic.sh images/test.jpg "1 2 3 4 6" 1 1
+```
+
 ## Run without benchmark (compile with openMP flag activated)
 
 To compile manually run:


### PR DESCRIPTION
## Summary
- expand root README with repo purpose, quick instructions and diagrams showing the monolith -> event-driven move
- add quick-start sections to each subproject README

## Testing
- `python3 -m py_compile microservices/grayscale/app.py event-driven/grayscale_service/app.py event-driven/frontend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685bc3d1627c832d86732526c70ee767